### PR TITLE
fix - sound: make the process terminate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ val PureConfigVersion = "0.12.3"
 val ScalaTestVersion = "3.0.1"
 val ScalaCheckVersion = "1.14.3"
 val ScalaArmVersion = "2.0"
+val LogbackVersion = "3.9.2"
+val LogbackBackend = "1.2.3"
 
 lazy val commonSettings = Seq(name := "SoundProcessing"
   , version := "0.1-SNAPSHOT")
@@ -27,4 +29,6 @@ lazy val sound = project.in(file("sound"))
   .settings(Defaults.itSettings)
   .settings(commonSettings: _*)
   .settings(Compile / mainClass := Some("com.jliermann.sound.Boot"))
-  .settings(libraryDependencies += "com.github.pureconfig" %% "pureconfig" % PureConfigVersion)
+  .settings(libraryDependencies += "com.github.pureconfig" %% "pureconfig" % PureConfigVersion
+    , libraryDependencies += "ch.qos.logback" % "logback-classic" % LogbackBackend
+    , libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % LogbackVersion)

--- a/sound/src/it/scala/com/jliermann/sound/JobIT.scala
+++ b/sound/src/it/scala/com/jliermann/sound/JobIT.scala
@@ -1,6 +1,5 @@
 package com.jliermann.sound
 
-import com.jliermann.sound.Boot.getTargetDataLine
 import com.jliermann.utils.test.{ResourcesTest, StreamTest}
 import com.typesafe.config.ConfigFactory
 
@@ -11,14 +10,11 @@ class JobIT extends StreamTest with ResourcesTest {
 
   "run" should "separate the word of the input" in {
     val rootConfig = RootConfiguration.loadConfigOrThrow(ConfigFactory.load())
-    for {
-      tdl <- getTargetDataLine(rootConfig.soundConfiguration.audioFormat)
-    } {
-      Await.result(Job.run(JobITEnvironment, rootConfig, tdl), 20.seconds)
-      val result = readFile(rootConfig.localConfiguration.outputFile)
-      result should have length 3
-      rootConfig.localConfiguration.outputFile.delete()
-    }
-  }
 
+    Await.result(Job.run(JobITEnvironment, rootConfig, null), 20.seconds)
+    val result = readFile(rootConfig.localConfiguration.outputFile)
+
+    result should have length 3
+    rootConfig.localConfiguration.outputFile.delete()
+  }
 }

--- a/sound/src/main/scala/com/jliermann/sound/Boot.scala
+++ b/sound/src/main/scala/com/jliermann/sound/Boot.scala
@@ -3,13 +3,28 @@ package com.jliermann.sound
 import akka.actor.ActorSystem
 import com.jliermann.sound.environment.EnvironmentLive
 import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
 
-private[sound] object Boot extends App with AudioApp {
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.io.StdIn
+import scala.util.{Failure, Success, Try}
+
+private[sound] object Boot extends App with AudioApp with LazyLogging {
+  implicit val actorSystem: ActorSystem = ActorSystem()
   val rootConfig = RootConfiguration.loadConfigOrThrow(ConfigFactory.load())
   for {
     tdl <- getTargetDataLine(rootConfig.soundConfiguration.audioFormat)
   } {
-    implicit val actorSystem: ActorSystem = ActorSystem()
     Job.run(EnvironmentLive, rootConfig, tdl)
+    logger.info("Speak into the microphone to start recording...")
+    logger.info("Press enter to stop...")
+    StdIn.readLine()
+    logger.info("Wait for the flow to end...")
+    Try(Await.result(actorSystem.terminate(), 10.second)) match {
+      case Success(_) => logger.info("Flow terminated successfully")
+      case Failure(exception) => throw exception
+    }
   }
+
 }

--- a/sound/src/main/scala/com/jliermann/sound/Job.scala
+++ b/sound/src/main/scala/com/jliermann/sound/Job.scala
@@ -12,7 +12,6 @@ import scala.concurrent.Future
 private[sound] object Job {
 
   def run(env: JobEnvironment, config: RootConfiguration, tdl: TargetDataLine)(implicit actorSystem: ActorSystem): Future[IOResult] = {
-    println("GOOOOO")
     env.wordSource.source(env, config.soundConfiguration, tdl)
       .map(_.map {
         case Pitched(xs) => xs.mkString("[", "; ", "]")
@@ -21,5 +20,5 @@ private[sound] object Job {
       .map(_.mkString("{", "---", "}"))
       .toMat(env.output.sinkToFile(config.localConfiguration.outputFile))(Keep.right)
       .run
-    }
+  }
 }

--- a/sound/src/test/scala/com/jliermann/sound/RootConfigurationSpec.scala
+++ b/sound/src/test/scala/com/jliermann/sound/RootConfigurationSpec.scala
@@ -1,9 +1,9 @@
 package com.jliermann.sound
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FlatSpec, Matchers, TryValues}
+import org.scalatest.{FlatSpec, Matchers}
 
-class RootConfigurationSpec extends FlatSpec with Matchers with TryValues {
+class RootConfigurationSpec extends FlatSpec with Matchers {
 
   "loadConfig" should "correctly load the configuration" in {
     noException shouldBe thrownBy(RootConfiguration.loadConfigOrThrow(ConfigFactory.load("referenceSpec.conf").resolve()))


### PR DESCRIPTION
The process ended in infinite loop, only force killable.
Sometimes (often), target data line closed abruptly because nothing waited for the future returned by the akka flow, making the audio ingestion ingesting nothing.

Now : 
added actorSystem.terminate after enter is read